### PR TITLE
Added target addresses/ports/protocols for Linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ It works by wrapping up some system tools in a portable(ish) way. On BSD-derived
 
 ```
 $ go get github.com/tylertreat/comcast
-$ go install github.com/typertreat/comcast
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -3,23 +3,31 @@
 
 Testing distributed systems under hard failures like network partitions and instance termination is critical, but it's also important we test them under [less catastrophic conditions](http://www.bravenewgeek.com/sometimes-kill-9-isnt-enough/) because this is what they most often experience. Comcast is a tool designed to simulate common network problems like latency, bandwidth restrictions, and dropped/reordered/corrupted packets.
 
-It works by wrapping up some system tools in a portable(ish) way. On BSD-derived systems such as OSX, we use tools like `ipfw` and `pfctl` to inject failure. On Linux, we use `iptables` and `tc`. Comcast is merely a thin wrapper around these controls.
+It works by wrapping up some system tools in a portable(ish) way. On BSD-derived systems such as OSX, we use tools like `ipfw` and `pfctl` to inject failure. On Linux, we use `iptables` and `tc`. Comcast is merely a thin wrapper around these controls. Windows support may be possible with `wipfw` or even the native network stack, but this has not yet been implemented in Comcast and may be at a later date.
 
 ## Installation
 
 ```
 $ go get github.com/tylertreat/comcast
+$ go install github.com/typertreat/comcast
 ```
 
 ## Usage
 
-Currently, Comcast supports just four options: device, latency, bandwidth, and packet loss.
+Currently (on Linux), Comcast supports several options: device, latency, target/default bandwidth, packet loss, protocol, and port number
 
 ```
-$ comcast --device=eth0 --latency=250 --bandwidth=1000 --packet-loss=0.1
+$ comcast --device=eth0 --latency=250 --target-bw=1000 --default-bw=1000000 --packet-loss=10% --target-addr=8.8.8.8,10.0.0.0/24 --target-proto=tcp,udp,icmp --target-port=80,22,1000:2000
 ```
 
-This will add 250ms of latency, limit bandwidth to 1Mbps, and drop 10% of packets. To turn this off, run the following:
+On OSX/BSD (with `ipfw`), Comcast currently supports only: device, latency, target bandwidth, packet loss.
+This will cease to be the case in a future (soon<sup>TM</sup>) update.
+
+```
+$ comcast --device eth0 --latency=250 --target-bw=1000 --packet-loss=10%
+```
+
+This will add 250ms of latency, limit bandwidth to 1Mbps, and drop 10% of packets to the targetted (on Linux) destination addresses using the specified protocols on the specified port numbers (slow lane). The default bandwidth specified will apply to all egress traffic (fast lane). To turn this off, run the following:
 
 ```
 $ comcast --mode stop

--- a/comcast.go
+++ b/comcast.go
@@ -2,27 +2,147 @@ package main
 
 import (
 	"flag"
-
-	"github.com/tylertreat/comcast/throttler"
+	"github.com/tylertreat/Comcast/throttler"
+	"log"
+	"net"
+	"strconv"
+	"strings"
 )
 
 func main() {
-	// TODO: add support for specific host/port.
-	// Also support for other options like packet reordering, duplication, etc.
+	// TODO: Add support for other options like packet reordering, duplication, etc.
 	var (
-		device     = flag.String("device", "eth0", "interface (device) to use")
-		mode       = flag.String("mode", throttler.Start, "start or stop packet controls")
-		latency    = flag.Int("latency", -1, "latency to add in ms")
-		bandwidth  = flag.Int("bandwidth", -1, "bandwidth limit in kb/s")
-		packetLoss = flag.Float64("packet-loss", 0, "packet-loss rate")
+		device      = flag.String("device", "", "interface (device) to use")
+		mode        = flag.String("mode", throttler.Start, "start or stop packet controls")
+		latency     = flag.Int("latency", -1, "latency to add in ms")
+		targetbw    = flag.Int("target-bw", -1, "target bandwidth limit in kb/s (slow-lane)")
+		defaultbw   = flag.Int("default-bw", -1, "default bandwidth limit in kb/s (fast-lane)")
+		packetLoss  = flag.Float64("packet-loss", 0, "packet-loss rate")
+		targetaddr  = flag.String("target-addr", "", "target addresses, (eg: 10.0.0.1 or 10.0.0.0/24 or 10.0.0.1,192.168.0.0/24)")
+		targetport  = flag.String("target-port", "", "target port(s) (eg: 80 or 1:65535 or 22,80,443,1000:1010)")
+		targetproto = flag.String("target-proto", "", "target protocol TCP/UDP (eg: tcp or tcp,udp or icmp)")
+		dryrun      = flag.Bool("dry-run", false, "specifies whether or not to actually commit the rule changes")
+		//icmptype    = flag.String("icmp-type", "", "icmp message type (eg: reply or reply,request)") //TODO: Maybe later :3
 	)
 	flag.Parse()
 
 	throttler.Run(&throttler.Config{
-		Device:     *device,
-		Mode:       *mode,
-		Latency:    *latency,
-		Bandwidth:  *bandwidth,
-		PacketLoss: *packetLoss,
+		Device:           *device,
+		Mode:             *mode,
+		Latency:          *latency,
+		TargetBandwidth:  *targetbw,
+		DefaultBandwidth: *defaultbw,
+		PacketLoss:       *packetLoss,
+		TargetIps:        parseAddrs(*targetaddr),
+		TargetPorts:      parsePorts(*targetport),
+		TargetProtos:     parseProtos(*targetproto),
+		DryRun:           *dryrun,
 	})
+}
+
+func parseAddrs(addrs string) []string {
+	adrs := strings.Split(addrs, ",")
+	parsed := []string{}
+
+	if addrs != "" {
+		for _, adr := range adrs {
+			ip := net.ParseIP(adr)
+			if ip != nil {
+				parsed = append(parsed, adr)
+			} else { //Not a valid single IP, could it be a CIDR?
+				_, net, err := net.ParseCIDR(adr)
+				if err == nil {
+					parsed = append(parsed, net.String())
+				} else {
+					log.Fatalln("Incorrectly specified target IP or CIDR", adr)
+				}
+			}
+		}
+	}
+
+	return parsed
+}
+
+func parsePorts(ports string) []string {
+	prts := strings.Split(ports, ",")
+	parsed := []string{}
+
+	if ports != "" {
+		for _, prt := range prts {
+			if strings.Contains(prt, ":") {
+				if validRange(prt) {
+					parsed = append(parsed, prt)
+				} else {
+					log.Fatalln("Incorrectly specified port range:", prt)
+				}
+			} else { //Isn't a range, check if just a single port
+				if validPort(prt) {
+					parsed = append(parsed, prt)
+				} else {
+					log.Fatalln("Incorrectly specified port:", prt)
+				}
+			}
+		}
+	}
+
+	return parsed
+}
+
+func parsePort(port string) int {
+	prt, err := strconv.Atoi(port)
+	if err != nil {
+		return 0
+	}
+
+	return prt
+}
+
+func validPort(port string) bool {
+	prt := parsePort(port)
+	return prt > 0 && prt < 65536
+}
+
+func validRange(ports string) bool {
+	pr := strings.Split(ports, ":")
+
+	if len(pr) == 2 {
+		if !validPort(pr[0]) || !validPort(pr[1]) {
+			return false
+		}
+
+		if portHigher(pr[0], pr[1]) {
+			return false
+		}
+	} else {
+		return false
+	}
+
+	return true
+}
+
+func portHigher(prt1, prt2 string) bool {
+	p1 := parsePort(prt1)
+	p2 := parsePort(prt2)
+
+	return p1 > p2
+}
+
+func parseProtos(protos string) []string {
+	ptcs := strings.Split(protos, ",")
+	parsed := []string{}
+
+	if protos != "" {
+		for _, ptc := range ptcs {
+			p := strings.ToLower(ptc)
+			if p == "udp" ||
+				p == "tcp" ||
+				p == "icmp" {
+				parsed = append(parsed, p)
+			} else {
+				log.Fatalln("Incorrectly specified protocol:", p)
+			}
+		}
+	}
+
+	return parsed
 }

--- a/throttler/ipfw.go
+++ b/throttler/ipfw.go
@@ -53,7 +53,7 @@ func (i *ipfwThrottler) buildConfigCommand(c *Config) string {
 	}
 
 	if c.PacketLoss > 0 {
-		cmd = cmd + " plr " + strconv.FormatFloat(c.PacketLoss, 'f', 2, 64)
+		cmd = cmd + " plr " + strconv.FormatFloat(c.PacketLoss/100, 'f', 4, 64)
 	}
 
 	return cmd

--- a/throttler/ipfw.go
+++ b/throttler/ipfw.go
@@ -32,7 +32,7 @@ func (i *ipfwThrottler) teardown(_ *Config) error {
 	return exec.Command("/bin/sh", "-c", ipfwTeardown).Run()
 }
 
-func (i *ipfwThrottler) exists() bool {
+func (i *ipfwThrottler) exists(_ *Config) bool {
 	fmt.Println(ipfwExists)
 	return exec.Command("/bin/sh", "-c", ipfwExists).Run() == nil
 }
@@ -48,8 +48,8 @@ func (i *ipfwThrottler) buildConfigCommand(c *Config) string {
 		cmd = cmd + " delay " + strconv.Itoa(c.Latency) + "ms"
 	}
 
-	if c.Bandwidth > 0 {
-		cmd = cmd + " bw " + strconv.Itoa(c.Bandwidth) + "Kbit/s"
+	if c.TargetBandwidth > 0 {
+		cmd = cmd + " bw " + strconv.Itoa(c.TargetBandwidth) + "Kbit/s"
 	}
 
 	if c.PacketLoss > 0 {

--- a/throttler/ipfw.go
+++ b/throttler/ipfw.go
@@ -1,8 +1,6 @@
 package throttler
 
 import (
-	"fmt"
-	"os/exec"
 	"strconv"
 )
 
@@ -17,24 +15,27 @@ const (
 type ipfwThrottler struct{}
 
 func (i *ipfwThrottler) setup(c *Config) error {
-	fmt.Println(ipfwAddPipe + c.Device)
-	if err := exec.Command("/bin/sh", "-c", ipfwAddPipe+c.Device).Run(); err != nil {
+	DRY = c.DryRun
+
+	cmd := ipfwAddPipe + c.Device
+	err := runCommand(cmd)
+	if err != nil {
 		return err
 	}
 
 	configCmd := i.buildConfigCommand(c)
-	fmt.Println(configCmd)
-	return exec.Command("/bin/sh", "-c", configCmd).Run()
+	err = runCommand(configCmd)
+	return err
 }
 
 func (i *ipfwThrottler) teardown(_ *Config) error {
-	fmt.Println(ipfwTeardown)
-	return exec.Command("/bin/sh", "-c", ipfwTeardown).Run()
+	err := runCommand(ipfwTeardown)
+	return err
 }
 
 func (i *ipfwThrottler) exists(_ *Config) bool {
-	fmt.Println(ipfwExists)
-	return exec.Command("/bin/sh", "-c", ipfwExists).Run() == nil
+	err := runCommand(ipfwExists)
+	return err == nil
 }
 
 func (i *ipfwThrottler) check() string {

--- a/throttler/tc.go
+++ b/throttler/tc.go
@@ -1,10 +1,7 @@
 package throttler
 
 import (
-	"bufio"
-	"errors"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 )
@@ -35,8 +32,6 @@ const (
 )
 
 type tcThrottler struct{}
-
-var DRY bool
 
 func (t *tcThrottler) setup(c *Config) error {
 
@@ -243,45 +238,4 @@ func (t *tcThrottler) exists(c *Config) bool {
 
 func (t *tcThrottler) check() string {
 	return tcCheck
-}
-
-func runCommand(cmd string) error {
-	fmt.Println(cmd)
-	if !DRY {
-		err := exec.Command("/bin/sh", "-c", cmd).Run()
-		return err
-	}
-	return nil
-}
-
-func runCommandGetLines(cmd string) ([]string, error) {
-
-	lines := []string{}
-	child := exec.Command("/bin/sh", "-c", cmd)
-
-	out, err := child.StdoutPipe()
-	if err != nil {
-		return []string{}, err
-	}
-
-	err = child.Start()
-	if err != nil {
-		return []string{}, err
-	}
-
-	scanner := bufio.NewScanner(out)
-
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-	if err := scanner.Err(); err != nil {
-		return []string{}, errors.New(fmt.Sprint("Error reading standard input:", err))
-	}
-
-	err = child.Wait()
-	if err != nil {
-		return []string{}, err
-	}
-
-	return lines, nil
 }

--- a/throttler/tc.go
+++ b/throttler/tc.go
@@ -199,23 +199,6 @@ func (t *tcThrottler) teardown(c *Config) error {
 		return err
 	}
 
-	// Apparently, removing the root qdisc we set up kill all the sub classes too!!!
-
-	// err = delDefaultClass(c) //The default class for all traffic that isn't classified
-	// if err != nil {
-	// 	return err
-	// }
-
-	// err = delTargetclass(c) //The class that the network emulator rule is assigned
-	// if err != nil {
-	// 	return err
-	// }
-
-	// err = delNetemRule(c) //The network emulator rule that contains the desired behavior
-	// if err != nil {
-	// 	return err
-	// }
-
 	return nil
 }
 
@@ -249,35 +232,6 @@ func delRootQDisc(c *Config) error {
 
 	return runCommand(cmd)
 }
-
-// func delDefaultClass(c *Config) error {
-// 	//Delete the default Class
-// 	def := fmt.Sprintf(tcDefaultClass, c.Device)
-
-// 	strs := []string{tcDelClass, def}
-// 	cmd := strings.Join(strs, " ")
-
-// 	return runCommand(cmd)
-// }
-
-// func delTargetclass(c *Config) error {
-// 	//Delete the target Class
-// 	tar := fmt.Sprintf(tcTargetClass, c.Device)
-// 	strs := []string{tcDelClass, tar}
-// 	cmd := strings.Join(strs, " ")
-
-// 	return runCommand(cmd)
-// }
-
-// func delNetemRule(c *Config) error {
-// 	//Delete the Network Emulator rule
-// 	net := fmt.Sprintf(tcNetemRule, c.Device)
-
-// 	strs := []string{tcDelQDisc, net}
-// 	cmd := strings.Join(strs, " ")
-
-// 	return runCommand(cmd)
-// }
 
 func (t *tcThrottler) exists(c *Config) bool {
 	if c.DryRun {

--- a/throttler/tc.go
+++ b/throttler/tc.go
@@ -122,7 +122,7 @@ func addNetemRule(c *Config) error {
 	}
 
 	if c.PacketLoss > 0 {
-		strs = append(strs, fmt.Sprintf(tcLoss, strconv.FormatFloat(c.PacketLoss*100, 'f', 0, 64)))
+		strs = append(strs, fmt.Sprintf(tcLoss, strconv.FormatFloat(c.PacketLoss, 'f', 2, 64)))
 	}
 
 	cmd := strings.Join(strs, " ")
@@ -280,11 +280,10 @@ func delRootQDisc(c *Config) error {
 // }
 
 func (t *tcThrottler) exists(c *Config) bool {
-	DRY = c.DryRun
-	err := runCommand(tcExists)
-	if DRY {
-		return true
+	if c.DryRun {
+		return false
 	}
+	err := runCommand(tcExists)
 	return err == nil
 }
 

--- a/throttler/tc.go
+++ b/throttler/tc.go
@@ -1,65 +1,334 @@
 package throttler
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strconv"
+	"strings"
 )
 
 const (
-	tcAdd      = `sudo tc qdisc add`
-	tcTeardown = `sudo tc qdisc del`
-	tcExists   = `sudo tc qdisc show | grep "netem"`
-	tcCheck    = `sudo tc -s qdisc`
+	tcRootQDisc    = `dev %s handle 10: root`
+	tcDefaultClass = `dev %s parent 10: classid 10:1`
+	tcTargetClass  = `dev %s parent 10:1 classid 10:10`
+	tcNetemRule    = `dev %s parent 10:10 handle 100:`
+	tcRate         = `rate %vkbit`
+	tcDelay        = `delay %vms`
+	tcLoss         = `loss %v%%`
+	tcAddClass     = `sudo tc class add`
+	tcDelClass     = `sudo tc class del`
+	tcAddQDisc     = `sudo tc qdisc add`
+	tcDelQDisc     = `sudo tc qdisc del`
+	iptAddTarget   = `sudo iptables -A POSTROUTING -t mangle -j CLASSIFY --set-class 10:10`
+	iptDelTarget   = `sudo iptables -D POSTROUTING -t mangle -j CLASSIFY --set-class 10:10`
+	iptDestIp      = `-d %s`
+	iptProto       = `-p %s`
+	iptDestPorts   = `--match multiport --dports %s`
+	iptDestPort    = `--dport %s`
+	iptDelSearch   = `class 0010:0010`
+	iptList        = `sudo iptables -S -t mangle`
+	iptDel         = `sudo iptables -t mangle -D`
+	tcExists       = `sudo tc qdisc show | grep "netem"`
+	tcCheck        = `sudo tc -s qdisc`
 )
 
 type tcThrottler struct{}
 
+var DRY bool
+
 func (t *tcThrottler) setup(c *Config) error {
-	cmd := t.buildConfigCommand(c)
-	fmt.Println(cmd)
-	return exec.Command("/bin/sh", "-c", cmd).Run()
+
+	DRY = c.DryRun
+
+	err := addRootQDisc(c) //The root node to append the filters
+	if err != nil {
+		return err
+	}
+
+	err = addDefaultClass(c) //The default class for all traffic that isn't classified
+	if err != nil {
+		return err
+	}
+
+	err = addTargetClass(c) //The class that the network emulator rule is assigned
+	if err != nil {
+		return err
+	}
+
+	err = addNetemRule(c) //The network emulator rule that contains the desired behavior
+	if err != nil {
+		return err
+	}
+
+	return addIptablesRules(c) //The network emulator rule that contains the desired behavior
+}
+
+func addRootQDisc(c *Config) error {
+	//Add the root QDisc
+	root := fmt.Sprintf(tcRootQDisc, c.Device)
+	strs := []string{tcAddQDisc, root, "htb"}
+	cmd := strings.Join(strs, " ")
+
+	return runCommand(cmd)
+}
+
+func addDefaultClass(c *Config) error {
+	//Add the default Class
+	def := fmt.Sprintf(tcDefaultClass, c.Device)
+	rate := ""
+
+	if c.DefaultBandwidth > 0 {
+		rate = fmt.Sprintf(tcRate, c.DefaultBandwidth)
+	} else {
+		rate = fmt.Sprintf(tcRate, 1000000)
+	}
+
+	strs := []string{tcAddClass, def, "htb", rate}
+	cmd := strings.Join(strs, " ")
+
+	return runCommand(cmd)
+}
+
+func addTargetClass(c *Config) error {
+	//Add the target Class
+	tar := fmt.Sprintf(tcTargetClass, c.Device)
+	rate := ""
+
+	if c.DefaultBandwidth > -1 {
+		rate = fmt.Sprintf(tcRate, c.DefaultBandwidth)
+	} else {
+		rate = fmt.Sprintf(tcRate, 1000000)
+	}
+
+	strs := []string{tcAddClass, tar, "htb", rate}
+	cmd := strings.Join(strs, " ")
+
+	return runCommand(cmd)
+}
+
+func addNetemRule(c *Config) error {
+	//Add the Network Emulator rule
+	net := fmt.Sprintf(tcNetemRule, c.Device)
+	strs := []string{tcAddQDisc, net, "netem"}
+
+	if c.Latency > 0 {
+		strs = append(strs, fmt.Sprintf(tcDelay, c.Latency))
+	}
+
+	if c.TargetBandwidth > -1 {
+		strs = append(strs, fmt.Sprintf(tcRate, c.TargetBandwidth))
+	}
+
+	if c.PacketLoss > 0 {
+		strs = append(strs, fmt.Sprintf(tcLoss, strconv.FormatFloat(c.PacketLoss*100, 'f', 0, 64)))
+	}
+
+	cmd := strings.Join(strs, " ")
+
+	return runCommand(cmd)
+}
+
+func addIptablesRules(c *Config) error {
+	rules := []string{}
+	ports := ""
+
+	if len(c.TargetPorts) > 0 {
+		if len(c.TargetPorts) > 1 {
+			prts := strings.Join(c.TargetPorts, ",")
+			ports = fmt.Sprintf(iptDestPorts, prts)
+		} else {
+			ports = fmt.Sprintf(iptDestPort, c.TargetPorts[0])
+		}
+	}
+
+	if len(c.TargetProtos) > 0 {
+		for _, ptc := range c.TargetProtos {
+			proto := fmt.Sprintf(iptProto, ptc)
+			rule := strings.Join([]string{iptAddTarget, proto}, " ")
+
+			if ptc != "icmp" {
+				if ports != "" {
+					rule += " " + ports
+				}
+			}
+
+			rules = append(rules, rule)
+		}
+	} else {
+		rules = []string{iptAddTarget}
+	}
+
+	if len(c.TargetIps) > 0 {
+		iprules := []string{}
+		for _, ip := range c.TargetIps {
+			dest := fmt.Sprintf(iptDestIp, ip)
+			if len(rules) > 0 {
+				for _, rule := range rules {
+					r := rule + " " + dest
+					iprules = append(iprules, r)
+				}
+			} else {
+				iprules = append(iprules, dest)
+			}
+		}
+		if len(iprules) > 0 {
+			rules = iprules
+		}
+	}
+
+	for _, rule := range rules {
+		err := runCommand(rule)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (t *tcThrottler) teardown(c *Config) error {
-	cmd := t.buildTeardownCommand(c)
-	fmt.Println(cmd)
-	return exec.Command("/bin/sh", "-c", cmd).Run()
+	err := delIptablesRules()
+	if err != nil {
+		return err
+	}
+
+	err = delRootQDisc(c) //The root node to append the filters
+	if err != nil {
+		return err
+	}
+
+	// Apparently, removing the root qdisc we set up kill all the sub classes too!!!
+
+	// err = delDefaultClass(c) //The default class for all traffic that isn't classified
+	// if err != nil {
+	// 	return err
+	// }
+
+	// err = delTargetclass(c) //The class that the network emulator rule is assigned
+	// if err != nil {
+	// 	return err
+	// }
+
+	// err = delNetemRule(c) //The network emulator rule that contains the desired behavior
+	// if err != nil {
+	// 	return err
+	// }
+
+	return nil
 }
 
-func (t *tcThrottler) exists() bool {
-	fmt.Println(tcExists)
-	return exec.Command("/bin/sh", "-c", tcExists).Run() == nil
+func delIptablesRules() error {
+	lines, err := runCommandGetLines(iptList)
+	if err != nil {
+		return err
+	}
+
+	if len(lines) > 0 {
+		for _, line := range lines {
+			if strings.Contains(line, iptDelSearch) {
+				cmd := strings.Replace(line, "-A", iptDel, 1)
+				err = runCommand(cmd)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func delRootQDisc(c *Config) error {
+	//Delete the root QDisc
+	root := fmt.Sprintf(tcRootQDisc, c.Device)
+
+	strs := []string{tcDelQDisc, root}
+	cmd := strings.Join(strs, " ")
+
+	return runCommand(cmd)
+}
+
+// func delDefaultClass(c *Config) error {
+// 	//Delete the default Class
+// 	def := fmt.Sprintf(tcDefaultClass, c.Device)
+
+// 	strs := []string{tcDelClass, def}
+// 	cmd := strings.Join(strs, " ")
+
+// 	return runCommand(cmd)
+// }
+
+// func delTargetclass(c *Config) error {
+// 	//Delete the target Class
+// 	tar := fmt.Sprintf(tcTargetClass, c.Device)
+// 	strs := []string{tcDelClass, tar}
+// 	cmd := strings.Join(strs, " ")
+
+// 	return runCommand(cmd)
+// }
+
+// func delNetemRule(c *Config) error {
+// 	//Delete the Network Emulator rule
+// 	net := fmt.Sprintf(tcNetemRule, c.Device)
+
+// 	strs := []string{tcDelQDisc, net}
+// 	cmd := strings.Join(strs, " ")
+
+// 	return runCommand(cmd)
+// }
+
+func (t *tcThrottler) exists(c *Config) bool {
+	DRY = c.DryRun
+	err := runCommand(tcExists)
+	if DRY {
+		return true
+	}
+	return err == nil
 }
 
 func (t *tcThrottler) check() string {
 	return tcCheck
 }
 
-func (t *tcThrottler) buildTeardownCommand(c *Config) string {
-	cmd := tcTeardown
-
-	cmd = cmd + " dev " + c.Device + " root netem"
-
-	return cmd
+func runCommand(cmd string) error {
+	fmt.Println(cmd)
+	if !DRY {
+		err := exec.Command("/bin/sh", "-c", cmd).Run()
+		return err
+	}
+	return nil
 }
 
-func (t *tcThrottler) buildConfigCommand(c *Config) string {
-	cmd := tcAdd
+func runCommandGetLines(cmd string) ([]string, error) {
 
-	cmd = cmd + " dev " + c.Device + " root netem"
+	lines := []string{}
+	child := exec.Command("/bin/sh", "-c", cmd)
 
-	if c.Latency > 0 {
-		cmd = cmd + " delay " + strconv.Itoa(c.Latency) + "ms"
+	out, err := child.StdoutPipe()
+	if err != nil {
+		return []string{}, err
 	}
 
-	if c.Bandwidth > 0 {
-		cmd = cmd + " rate " + strconv.Itoa(c.Bandwidth) + "kbit"
+	err = child.Start()
+	if err != nil {
+		return []string{}, err
 	}
 
-	if c.PacketLoss > 0 {
-		cmd = cmd + " loss " + strconv.FormatFloat(c.PacketLoss*100, 'f', 0, 64) + "%"
+	scanner := bufio.NewScanner(out)
+
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return []string{}, errors.New(fmt.Sprint("Error reading standard input:", err))
 	}
 
-	return cmd
+	err = child.Wait()
+	if err != nil {
+		return []string{}, err
+	}
+
+	return lines, nil
 }

--- a/throttler/throttler.go
+++ b/throttler/throttler.go
@@ -1,6 +1,9 @@
 package throttler
 
 import (
+	"bufio"
+	"errors"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -40,6 +43,8 @@ type throttler interface {
 	exists(*Config) bool
 	check() string
 }
+
+var DRY bool
 
 func setup(t throttler, c *Config) {
 	if t.exists(c) {
@@ -125,4 +130,45 @@ func osxVersionSupported() bool {
 		return false
 	}
 	return !strings.HasPrefix(string(v), "10.10")
+}
+
+func runCommand(cmd string) error {
+	fmt.Println(cmd)
+	if !DRY {
+		err := exec.Command("/bin/sh", "-c", cmd).Run()
+		return err
+	}
+	return nil
+}
+
+func runCommandGetLines(cmd string) ([]string, error) {
+
+	lines := []string{}
+	child := exec.Command("/bin/sh", "-c", cmd)
+
+	out, err := child.StdoutPipe()
+	if err != nil {
+		return []string{}, err
+	}
+
+	err = child.Start()
+	if err != nil {
+		return []string{}, err
+	}
+
+	scanner := bufio.NewScanner(out)
+
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return []string{}, errors.New(fmt.Sprint("Error reading standard input:", err))
+	}
+
+	err = child.Wait()
+	if err != nil {
+		return []string{}, err
+	}
+
+	return lines, nil
 }

--- a/throttler/throttler.go
+++ b/throttler/throttler.go
@@ -1,7 +1,7 @@
 package throttler
 
 import (
-	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"runtime"
@@ -16,55 +16,57 @@ const (
 	linux           = "linux"
 	darwin          = "darwin"
 	freebsd         = "freebsd"
+	windows         = "windows"
 	checkOSXVersion = "sw_vers -productVersion"
 )
 
 // Config specifies options for configuring packet filter rules.
 type Config struct {
-	Device     string
-	Mode       string
-	Latency    int
-	Bandwidth  int
-	PacketLoss float64
+	Device           string
+	Mode             string
+	Latency          int
+	TargetBandwidth  int
+	DefaultBandwidth int
+	PacketLoss       float64
+	TargetIps        []string
+	TargetPorts      []string
+	TargetProtos     []string
+	DryRun           bool
 }
 
 type throttler interface {
 	setup(*Config) error
 	teardown(*Config) error
-	exists() bool
+	exists(*Config) bool
 	check() string
 }
 
 func setup(t throttler, c *Config) {
-	if t.exists() {
-		fmt.Println("It looks like the packet rules are already setup")
-		os.Exit(1)
+	if t.exists(c) {
+		log.Fatalln("It looks like the packet rules are already setup")
 	}
 
 	if err := t.setup(c); err != nil {
-		fmt.Println("I couldn't setup the packet rules")
-		os.Exit(1)
+		log.Fatalln("I couldn't setup the packet rules")
 	}
 
-	fmt.Println("Packet rules setup...")
-	fmt.Printf("Run `%s` to double check\n", t.check())
-	fmt.Printf("Run `%s --mode %s` to reset\n", os.Args[0], stop)
+	log.Println("Packet rules setup...")
+	log.Printf("Run `%s` to double check\n", t.check())
+	log.Printf("Run `%s --mode %s` to reset\n", os.Args[0], stop)
 }
 
 func teardown(t throttler, c *Config) {
-	if !t.exists() {
-		fmt.Println("It looks like the packet rules aren't setup")
-		os.Exit(1)
+	if !t.exists(c) {
+		log.Fatalln("It looks like the packet rules aren't setup")
 	}
 
 	if err := t.teardown(c); err != nil {
-		fmt.Println("Failed to stop packet controls")
-		os.Exit(1)
+		log.Fatalln("Failed to stop packet controls")
 	}
 
-	fmt.Println("Packet rules stopped...")
-	fmt.Printf("Run `%s` to double check\n", t.check())
-	fmt.Printf("Run `%s --mode %s` to start\n", os.Args[0], Start)
+	log.Println("Packet rules stopped...")
+	log.Printf("Run `%s` to double check\n", t.check())
+	log.Printf("Run `%s --mode %s` to start\n", os.Args[0], Start)
 }
 
 // Run executes the packet filter operation, either setting it up or tearing
@@ -72,19 +74,38 @@ func teardown(t throttler, c *Config) {
 func Run(c *Config) {
 	var t throttler
 	switch runtime.GOOS {
-	case darwin, freebsd:
+	case freebsd:
+		if c.Device == "" {
+			log.Fatalln("Device not specified, unable to default to eth0 on FreeBSD.")
+		}
+
+		t = &ipfwThrottler{}
+	case darwin:
 		if runtime.GOOS == darwin && !osxVersionSupported() {
 			// ipfw was removed in OSX 10.10 in favor of pfctl.
+			log.Fatalln("I don't support your version of OSX")
+
 			// TODO: add support for pfctl.
-			fmt.Println("I don't support your version of OSX")
-			os.Exit(1)
+			//t = &pfctlThrottler{}
 		}
+
+		if c.Device == "" {
+			c.Device = "eth0"
+		}
+
 		t = &ipfwThrottler{}
 	case linux:
+		if c.Device == "" {
+			c.Device = "eth0"
+		}
+
 		t = &tcThrottler{}
+	case windows:
+		log.Fatalln("I don't support your OS: %s\n", runtime.GOOS)
+		//log.Fatalln("If you want to use Comcast on Windows, please install wipfw.")
+		//t = &wipfwThrottler{}
 	default:
-		fmt.Printf("I don't support your OS: %s\n", runtime.GOOS)
-		os.Exit(1)
+		log.Fatalln("I don't support your OS: %s\n", runtime.GOOS)
 	}
 
 	switch c.Mode {
@@ -93,9 +114,8 @@ func Run(c *Config) {
 	case stop:
 		teardown(t, c)
 	default:
-		fmt.Printf("I don't know what this mode is: %s\n", c.Mode)
-		fmt.Printf("Try %q or %q\n", Start, stop)
-		os.Exit(1)
+		log.Printf("I don't know what this mode is: %s\n", c.Mode)
+		log.Fatalf("Try %q or %q\n", Start, stop)
 	}
 }
 


### PR DESCRIPTION
-Added --dry-run to not commit any changes
-Can specify the default bandwidth limit of non-targetted connections with --default-bw (fast-lanes) Will add support for also affecting latency/packet loss for default connections at a later date.
-Mac/BSD using ipfw not yet supported for target addresses/ports/protocols
-Mac/BSD must use --target-bw now instead of --bandwidth