### PR TITLE
Cleanup Dry-Run Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Here's a list of network conditions to that you can plug into Comcast. Please ad
 
 Name | Latency | Bandwidth | Packet-loss
 :-- | --: | --: | --:
+DIALUP good | 40 | 185 | 2
 GPRS good | 500 | 50 | 2
 EDGE good | 300 | 250 | 1.5
 3G(HSDPA) good | 250 | 750 | 1.5

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Here's a list of network conditions to that you can plug into Comcast. Please ad
 
 Name | Latency | Bandwidth | Packet-loss
 :-- | --: | --: | --:
-DIALUP good | 40 | 185 | 2
 GPRS good | 500 | 50 | 2
 EDGE good | 300 | 250 | 1.5
 3G(HSDPA) good | 250 | 750 | 1.5
+DIALUP good | 185 | 40 | 2
 DSL (poor) | 70 | 2000 | 2
 DSL (good) | 40 | 8000 | 0.5
 WIFI (good) | 40 | 30000 | 0.2

--- a/throttler/ipfw.go
+++ b/throttler/ipfw.go
@@ -15,8 +15,6 @@ const (
 type ipfwThrottler struct{}
 
 func (i *ipfwThrottler) setup(c *Config) error {
-	DRY = c.DryRun
-
 	cmd := ipfwAddPipe + c.Device
 	err := runCommand(cmd)
 	if err != nil {
@@ -33,7 +31,10 @@ func (i *ipfwThrottler) teardown(_ *Config) error {
 	return err
 }
 
-func (i *ipfwThrottler) exists(_ *Config) bool {
+func (i *ipfwThrottler) exists() bool {
+	if DRY {
+		return false
+	}
 	err := runCommand(ipfwExists)
 	return err == nil
 }

--- a/throttler/tc.go
+++ b/throttler/tc.go
@@ -34,9 +34,6 @@ const (
 type tcThrottler struct{}
 
 func (t *tcThrottler) setup(c *Config) error {
-
-	DRY = c.DryRun
-
 	err := addRootQDisc(c) //The root node to append the filters
 	if err != nil {
 		return err
@@ -228,8 +225,8 @@ func delRootQDisc(c *Config) error {
 	return runCommand(cmd)
 }
 
-func (t *tcThrottler) exists(c *Config) bool {
-	if c.DryRun {
+func (t *tcThrottler) exists() bool {
+	if DRY {
 		return false
 	}
 	err := runCommand(tcExists)

--- a/throttler/throttler.go
+++ b/throttler/throttler.go
@@ -40,14 +40,14 @@ type Config struct {
 type throttler interface {
 	setup(*Config) error
 	teardown(*Config) error
-	exists(*Config) bool
+	exists() bool
 	check() string
 }
 
 var DRY bool
 
 func setup(t throttler, c *Config) {
-	if t.exists(c) {
+	if t.exists() {
 		log.Fatalln("It looks like the packet rules are already setup")
 	}
 
@@ -61,7 +61,7 @@ func setup(t throttler, c *Config) {
 }
 
 func teardown(t throttler, c *Config) {
-	if !t.exists(c) {
+	if !t.exists() {
 		log.Fatalln("It looks like the packet rules aren't setup")
 	}
 
@@ -77,6 +77,7 @@ func teardown(t throttler, c *Config) {
 // Run executes the packet filter operation, either setting it up or tearing
 // it down.
 func Run(c *Config) {
+	DRY = c.DryRun
 	var t throttler
 	switch runtime.GOOS {
 	case freebsd:


### PR DESCRIPTION
Pushes the runCommand/GetLines functions into the main throttler.go file, DRY global is set now in throttler.go so *Config does not need to be passed to exists() like it was originally, and makes dry runs more reliable to track down between ipfw and tc wrappers.