### PR TITLE
Change dependency capitalization

### DIFF
--- a/comcast.go
+++ b/comcast.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"github.com/tylertreat/Comcast/throttler"
+	"github.com/tylertreat/comcast/throttler"
 	"log"
 	"net"
 	"strconv"


### PR DESCRIPTION
This way the code will not be pulled in twice by the install command in the README.

It might be good to uncapitalize the github repo name as well. See #25 as to why this is changed instead of the README.