### PR TITLE
Add unit tests for tc throttler

### DIFF
--- a/throttler/ipfw.go
+++ b/throttler/ipfw.go
@@ -12,22 +12,24 @@ const (
 	ipfwCheck    = `sudo ipfw list`
 )
 
-type ipfwThrottler struct{}
+type ipfwThrottler struct {
+	c commander
+}
 
 func (i *ipfwThrottler) setup(c *Config) error {
 	cmd := ipfwAddPipe + c.Device
-	err := runCommand(cmd)
+	err := i.c.execute(cmd)
 	if err != nil {
 		return err
 	}
 
 	configCmd := i.buildConfigCommand(c)
-	err = runCommand(configCmd)
+	err = i.c.execute(configCmd)
 	return err
 }
 
 func (i *ipfwThrottler) teardown(_ *Config) error {
-	err := runCommand(ipfwTeardown)
+	err := i.c.execute(ipfwTeardown)
 	return err
 }
 
@@ -35,7 +37,7 @@ func (i *ipfwThrottler) exists() bool {
 	if dry {
 		return false
 	}
-	err := runCommand(ipfwExists)
+	err := i.c.execute(ipfwExists)
 	return err == nil
 }
 

--- a/throttler/tc_test.go
+++ b/throttler/tc_test.go
@@ -1,0 +1,122 @@
+package throttler
+
+import (
+	"testing"
+)
+
+type cmdRecorder struct {
+	commands     []string
+	responses    [][]string
+	lastResponse int
+}
+
+func newCmdRecorder() *cmdRecorder {
+	return &cmdRecorder{[]string{}, [][]string{}, -1}
+}
+
+func (r *cmdRecorder) execute(cmd string) error {
+	r.commands = append(r.commands, cmd)
+	return nil
+}
+
+func (r *cmdRecorder) executeGetLines(cmd string) ([]string, error) {
+	r.execute(cmd)
+	if len(r.responses) > 0 {
+		r.lastResponse = (r.lastResponse + 1) % len(r.responses)
+		return r.responses[r.lastResponse], nil
+	}
+	return []string{}, nil
+}
+
+func (r *cmdRecorder) verifyCommands(t *testing.T, expected []string) {
+	if len(expected) != len(r.commands) {
+		t.Fatalf("Expected to see %d commands, got %d", len(expected), len(r.commands))
+	}
+
+	for i, cmd := range expected {
+		if actual := r.commands[i]; actual != cmd {
+			t.Fatalf("Expected to see command `%s`, got `%s`", cmd, actual)
+		}
+	}
+}
+
+var defaultTestConfig = Config{
+	Device:           "eth0",
+	Mode:             Start,
+	Latency:          -1,
+	TargetBandwidth:  -1,
+	DefaultBandwidth: 20000,
+	PacketLoss:       0.1,
+	TargetIps:        []string{"10.10.10.10"},
+	TargetPorts:      []string{"80"},
+	TargetProtos:     []string{"tcp"},
+	DryRun:           false,
+}
+
+func TestTcPacketLossSetup(t *testing.T) {
+	r := newCmdRecorder()
+	th := &tcThrottler{r}
+	cfg := defaultTestConfig
+	cfg.Device = "eth1"
+	cfg.PacketLoss = 0.2
+	th.setup(&cfg)
+	r.verifyCommands(t, []string{
+		"sudo tc qdisc add dev eth1 handle 10: root htb",
+		"sudo tc class add dev eth1 parent 10: classid 10:1 htb rate 20000kbit",
+		"sudo tc class add dev eth1 parent 10:1 classid 10:10 htb rate 20000kbit",
+		"sudo tc qdisc add dev eth1 parent 10:10 handle 100: netem loss 0.20%",
+		"sudo iptables -A POSTROUTING -t mangle -j CLASSIFY --set-class 10:10 -p tcp --dport 80 -d 10.10.10.10",
+	})
+}
+
+func TestTcMultiplePortsAndIps(t *testing.T) {
+	r := newCmdRecorder()
+	th := &tcThrottler{r}
+	cfg := defaultTestConfig
+	cfg.TargetIps = []string{"1.1.1.1", "2.2.2.2"}
+	cfg.TargetPorts = []string{"80", "8080"}
+	cfg.TargetProtos = []string{"tcp", "udp"}
+	th.setup(&cfg)
+	r.verifyCommands(t, []string{
+		"sudo tc qdisc add dev eth0 handle 10: root htb",
+		"sudo tc class add dev eth0 parent 10: classid 10:1 htb rate 20000kbit",
+		"sudo tc class add dev eth0 parent 10:1 classid 10:10 htb rate 20000kbit",
+		"sudo tc qdisc add dev eth0 parent 10:10 handle 100: netem loss 0.10%",
+		"sudo iptables -A POSTROUTING -t mangle -j CLASSIFY --set-class 10:10 -p tcp --match multiport --dports 80,8080 -d 1.1.1.1",
+		"sudo iptables -A POSTROUTING -t mangle -j CLASSIFY --set-class 10:10 -p udp --match multiport --dports 80,8080 -d 1.1.1.1",
+		"sudo iptables -A POSTROUTING -t mangle -j CLASSIFY --set-class 10:10 -p tcp --match multiport --dports 80,8080 -d 2.2.2.2",
+		"sudo iptables -A POSTROUTING -t mangle -j CLASSIFY --set-class 10:10 -p udp --match multiport --dports 80,8080 -d 2.2.2.2",
+
+	})
+}
+
+func TestTcTeardown(t *testing.T) {
+	r := newCmdRecorder()
+	th := &tcThrottler{r}
+	r.responses = [][]string{
+		{
+			"-P PREROUTING ACCEPT",
+			"-P INPUT ACCEPT",
+			"-P FORWARD ACCEPT",
+			"-P OUTPUT ACCEPT",
+			"-P POSTROUTING ACCEPT",
+			"-A POSTROUTING -d 10.10.10.10 -p tcp -m tcp --dport 80 -j CLASSIFY --set-class 0010:0010",
+		},
+	}
+	th.teardown(&defaultTestConfig)
+	r.verifyCommands(t, []string{
+		"sudo iptables -S -t mangle",
+		"sudo iptables -t mangle -D POSTROUTING -d 10.10.10.10 -p tcp -m tcp --dport 80 -j CLASSIFY --set-class 0010:0010",
+		"sudo tc qdisc del dev eth0 handle 10: root",
+	})
+}
+
+func TestTcTeardownNoIpTables(t *testing.T) {
+	r := newCmdRecorder()
+	th := &tcThrottler{r}
+	th.teardown(&defaultTestConfig)
+	r.verifyCommands(t, []string{
+		"sudo iptables -S -t mangle",
+		"sudo tc qdisc del dev eth0 handle 10: root",
+	})
+}


### PR DESCRIPTION
Introduce interface `commander` to make unit tests possible. Now all
commands execution goes through instances of this interface.

I'm planning to add `ip6tables` support to the tc throttler, this would require some refactoring. I started from unit tests just to reduce the probability of regression. It's nice to have them anyway.