### PR TITLE
Add ipv6 destination support on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ $ go get github.com/tylertreat/comcast
 
 ## Usage
 
-Currently (on Linux), Comcast supports several options: device, latency, target/default bandwidth, packet loss, protocol, and port number
+Currently (on Linux), Comcast supports several options: device, latency, target/default bandwidth, packet loss, ipv6, protocol, and port number
 
 ```
 $ comcast --device=eth0 --latency=250 --target-bw=1000 --default-bw=1000000 --packet-loss=10% --target-addr=8.8.8.8,10.0.0.0/24 --target-proto=tcp,udp,icmp --target-port=80,22,1000:2000
 ```
+
+The `--ipv6` option enables ipv6 target addresses support. You can't mix ipv6 and ipv4 addresses in a single command invocation. In addition, rules added with the `--ipv6` option should be also removed with this option enabled: `comcat --ipv6 --mode=stop`.
 
 On OSX/BSD (with `ipfw`), Comcast currently supports only: device, latency, target bandwidth, packet loss.
 This will cease to be the case in a future (soon<sup>TM</sup>) update.

--- a/comcast.go
+++ b/comcast.go
@@ -22,6 +22,7 @@ func main() {
 		targetport  = flag.String("target-port", "", "Target port(s) (eg: 80 or 1:65535 or 22,80,443,1000:1010)")
 		targetproto = flag.String("target-proto", "tcp,udp,icmp", "Target protocol TCP/UDP (eg: tcp or tcp,udp or icmp)")
 		dryrun      = flag.Bool("dry-run", false, "Specifies whether or not to actually commit the rule changes")
+		ipv6        = flag.Bool("ipv6", false, "Enable IPv6 support")
 		//icmptype    = flag.String("icmp-type", "", "icmp message type (eg: reply or reply,request)") //TODO: Maybe later :3
 	)
 	flag.Parse()
@@ -37,6 +38,7 @@ func main() {
 		TargetPorts:      parsePorts(*targetport),
 		TargetProtos:     parseProtos(*targetproto),
 		DryRun:           *dryrun,
+		IPv6:             *ipv6,
 	})
 }
 

--- a/throttler/throttler.go
+++ b/throttler/throttler.go
@@ -35,6 +35,7 @@ type Config struct {
 	TargetPorts      []string
 	TargetProtos     []string
 	DryRun           bool
+	IPv6             bool
 }
 
 type throttler interface {
@@ -49,9 +50,9 @@ type commander interface {
 	executeGetLines(string) ([]string, error)
 }
 
-type dryRunCommander struct {}
+type dryRunCommander struct{}
 
-type shellCommander struct {}
+type shellCommander struct{}
 
 var dry bool
 
@@ -64,9 +65,14 @@ func setup(t throttler, cfg *Config) {
 		log.Fatalln("I couldn't setup the packet rules")
 	}
 
+	ipVersionOption := ""
+	if cfg.IPv6 {
+		ipVersionOption = "--ipv6"
+	}
+
 	log.Println("Packet rules setup...")
 	log.Printf("Run `%s` to double check\n", t.check())
-	log.Printf("Run `%s --mode %s` to reset\n", os.Args[0], stop)
+	log.Printf("Run `%s %s --mode %s` to reset\n", os.Args[0], ipVersionOption, stop)
 }
 
 func teardown(t throttler, cfg *Config) {


### PR DESCRIPTION
Now it's possible to specify IPv6 address as a destination using the `--ipv6` command line option:
```
comcast --packet-loss=20% --ipv6 --target-addr=2001:db8::1 --target-proto=tcp --target-port=80
```