### PR TITLE
Fix shaping default bandwidth

### DIFF
--- a/throttler/tc.go
+++ b/throttler/tc.go
@@ -10,8 +10,9 @@ import (
 
 const (
 	tcRootQDisc    = `dev %s handle 10: root`
+	tcRootExtra    = `default 1`
 	tcDefaultClass = `dev %s parent 10: classid 10:1`
-	tcTargetClass  = `dev %s parent 10:1 classid 10:10`
+	tcTargetClass  = `dev %s parent 10: classid 10:10`
 	tcNetemRule    = `dev %s parent 10:10 handle 100:`
 	tcRate         = `rate %vkbit`
 	tcDelay        = `delay %vms`
@@ -66,7 +67,7 @@ func (t *tcThrottler) setup(cfg *Config) error {
 func addRootQDisc(cfg *Config, c commander) error {
 	//Add the root QDisc
 	root := fmt.Sprintf(tcRootQDisc, cfg.Device)
-	strs := []string{tcAddQDisc, root, "htb"}
+	strs := []string{tcAddQDisc, root, "htb", tcRootExtra}
 	cmd := strings.Join(strs, " ")
 
 	return c.execute(cmd)
@@ -94,8 +95,8 @@ func addTargetClass(cfg *Config, c commander) error {
 	tar := fmt.Sprintf(tcTargetClass, cfg.Device)
 	rate := ""
 
-	if cfg.DefaultBandwidth > -1 {
-		rate = fmt.Sprintf(tcRate, cfg.DefaultBandwidth)
+	if cfg.TargetBandwidth > -1 {
+		rate = fmt.Sprintf(tcRate, cfg.TargetBandwidth)
 	} else {
 		rate = fmt.Sprintf(tcRate, 1000000)
 	}


### PR DESCRIPTION
The current code uses cfg.DefaultBandwidth when addTargetClass() which
is not right at first sight.

The other thing is that HTB seems to have a default built-in class where
all unclassified packets will go into.  This can be checked with value
of direct_packets_stats in output of "tc qdisc show dev eth0", and as
such we need to explicitly set the default class to 10:1 to handle this