### PR TITLE
Fix tests, add travis, no ips means all ips

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+go:
+  - 1.8.x
+
+script:
+  - go test -v ./...

--- a/throttler/tc.go
+++ b/throttler/tc.go
@@ -131,6 +131,15 @@ func addNetemRule(cfg *Config, c commander) error {
 
 func addIptablesRules(cfg *Config, c commander) error {
 	var err error
+	if len(cfg.TargetIps) == 0 && len(cfg.TargetIps6) == 0 {
+		if err == nil {
+			err = addIptablesRulesForAddrs(cfg, c, ip4Tables, cfg.TargetIps)
+		}
+		if err == nil {
+			err = addIptablesRulesForAddrs(cfg, c, ip6Tables, cfg.TargetIps6)
+		}
+		return err
+	}
 	if err == nil && len(cfg.TargetIps) > 0 {
 		err = addIptablesRulesForAddrs(cfg, c, ip4Tables, cfg.TargetIps)
 	}

--- a/throttler/tc_test.go
+++ b/throttler/tc_test.go
@@ -50,7 +50,7 @@ func (r *cmdRecorder) verifyCommands(t *testing.T, expected []string) {
 
 	for i, cmd := range expected {
 		if actual := r.commands[i]; actual != cmd {
-			t.Fatalf("Expected to see command `%s`, got `%s`", i, cmd, actual)
+			t.Fatalf("Expected to see command `%s`, got `%s`", cmd, actual)
 		}
 	}
 }
@@ -76,9 +76,9 @@ func TestTcPacketLossSetup(t *testing.T) {
 	cfg.PacketLoss = 0.2
 	th.setup(&cfg)
 	r.verifyCommands(t, []string{
-		"sudo tc qdisc add dev eth1 handle 10: root htb",
+		"sudo tc qdisc add dev eth1 handle 10: root htb default 1",
 		"sudo tc class add dev eth1 parent 10: classid 10:1 htb rate 20000kbit",
-		"sudo tc class add dev eth1 parent 10:1 classid 10:10 htb rate 20000kbit",
+		"sudo tc class add dev eth1 parent 10: classid 10:10 htb rate 1000000kbit",
 		"sudo tc qdisc add dev eth1 parent 10:10 handle 100: netem loss 0.20%",
 		"sudo iptables -A POSTROUTING -t mangle -j CLASSIFY --set-class 10:10 -p tcp --dport 80 -d 10.10.10.10",
 	})
@@ -93,9 +93,9 @@ func TestTcMultiplePortsAndIps(t *testing.T) {
 	cfg.TargetProtos = []string{"tcp", "udp"}
 	th.setup(&cfg)
 	r.verifyCommands(t, []string{
-		"sudo tc qdisc add dev eth0 handle 10: root htb",
+		"sudo tc qdisc add dev eth0 handle 10: root htb default 1",
 		"sudo tc class add dev eth0 parent 10: classid 10:1 htb rate 20000kbit",
-		"sudo tc class add dev eth0 parent 10:1 classid 10:10 htb rate 20000kbit",
+		"sudo tc class add dev eth0 parent 10: classid 10:10 htb rate 1000000kbit",
 		"sudo tc qdisc add dev eth0 parent 10:10 handle 100: netem loss 0.10%",
 		"sudo iptables -A POSTROUTING -t mangle -j CLASSIFY --set-class 10:10 -p tcp --match multiport --dports 80,8080 -d 1.1.1.1",
 		"sudo iptables -A POSTROUTING -t mangle -j CLASSIFY --set-class 10:10 -p udp --match multiport --dports 80,8080 -d 1.1.1.1",
@@ -113,9 +113,9 @@ func TestTcMixedIPv6Setup(t *testing.T) {
 	cfg.TargetIps6 = []string{"2001:db8::1"}
 	th.setup(&cfg)
 	r.verifyCommands(t, []string{
-		"sudo tc qdisc add dev eth1 handle 10: root htb",
+		"sudo tc qdisc add dev eth1 handle 10: root htb default 1",
 		"sudo tc class add dev eth1 parent 10: classid 10:1 htb rate 20000kbit",
-		"sudo tc class add dev eth1 parent 10:1 classid 10:10 htb rate 20000kbit",
+		"sudo tc class add dev eth1 parent 10: classid 10:10 htb rate 1000000kbit",
 		"sudo tc qdisc add dev eth1 parent 10:10 handle 100: netem loss 0.20%",
 		"sudo iptables -A POSTROUTING -t mangle -j CLASSIFY --set-class 10:10 -p tcp --dport 80 -d 10.10.10.10",
 		"sudo ip6tables -A POSTROUTING -t mangle -j CLASSIFY --set-class 10:10 -p tcp --dport 80 -d 2001:db8::1",


### PR DESCRIPTION
This PR fixes some tests, then adds travis to make sure they don't break again. To try travis I think you just need enable travis for this repo, then close and reopen this PR to get it picked up.

It also undoes a (possibly unintentional, cc @roman-kashitsyn) change from https://github.com/tylertreat/comcast/pull/34/files#diff-37cc0cdfa4b91e523551b72469d7abeaR129 where previously passing no IP addresses applies rules to all IPs, but afterwards it would apply to none (the iptables commands wouldn't be run at all). This manifests in the form of packet loss options not applying, though bandwidth limits still happen.