### PR TITLE
Update README.md to use 'go install' instead of 'go get'

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It works by wrapping up some system tools in a portable(ish) way. On BSD-derived
 ## Installation
 
 ```
-$ go get github.com/tylertreat/comcast
+$ go install github.com/tylertreat/comcast@latest
 ```
 
 ## Usage


### PR DESCRIPTION
'go get' is deprecated now.
https://go.dev/doc/go-get-install-deprecation
"Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead."
'go install github.com/tylertreat/comcast@latest' worked fine.