### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ It works by wrapping up some system tools in a portable(ish) way. On BSD-derived
 $ go install github.com/tylertreat/comcast@latest
 ```
 
+### Path addition may be needed
+
+In unix-like systems, after installing comcast with go, it may be needed to add it to the `PATH`. Go installs by default in `$HOME/go/bin`.
+```
+$ export PATH=$PATH:$HOME/go/bin
+```
+
 ## Usage
 
 On Linux, Comcast supports several options: device, latency, target/default bandwidth, packet loss, protocol, and port number.


### PR DESCRIPTION
Adding extra step needed in unix-like systems.
This will let people with OSX and Linux to follow the README.md without getting `comcast: command not found`.